### PR TITLE
[ :sparkles: | #27 | feature] 교수님 페이지 생성

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,11 +1,12 @@
 export const routes = {
 	home: '/home',
 	people: '/people',
+	professor: '/people/professor',
 	projects: '/projects',
 	publications: '/publications',
 	lectures: '/lectures',
 	club: '/전공동아리',
-	// TODO: 교수님 접속 가능 페이지 추가
+	// TODO: 교수님 접속 가능 페이지 추가 -> 완료
 	secret: {
 		login: '/secret/login',
 		professor: '/secret/professor',

--- a/src/layout/header.tsx
+++ b/src/layout/header.tsx
@@ -10,39 +10,39 @@ export default function Header() {
 
 	return (
 		<>
-			<header className="fixed top-0 flex items-center justify-between w-full z-[999] h-14 bg-gradient-to-r from-sky-500 to-indigo-500">
-				<div className="flex items-center ml-32">
-					<Link to="home" className="text-white logo">
-						<img src="src/assets/images/header/kw-logo.png" alt="KW MARK" className="w-36" />
+			<header className='fixed top-0 flex items-center justify-between w-full z-[999] h-14 bg-gradient-to-r from-sky-500 to-indigo-500'>
+				<div className='flex items-center ml-32'>
+					<Link to='home' className='text-white logo'>
+						<img src='../src/assets/images/header/kw-logo.png' alt='KW MARK' className='w-36' />
 					</Link>
-					<Link to="home" className="ml-4 text-white logo">
-						<h3 className="text-xl font-bold">KW-HCC LAB</h3>
+					<Link to='home' className='ml-4 text-white logo'>
+						<h3 className='text-xl font-bold'>KW-HCC LAB</h3>
 					</Link>
 				</div>
-				<nav className="mr-32">
-					<ul className="flex items-center justify-center mr-10 space-x-8 text-white navi">
+				<nav className='mr-32'>
+					<ul className='flex items-center justify-center mr-10 space-x-8 text-white navi'>
 						<li>
-							<Link to="people" className={getLinkStyle('/people')}>
+							<Link to='people' className={getLinkStyle('/people')}>
 								PEOPLE
 							</Link>
 						</li>
 						<li>
-							<Link to="projects" className={getLinkStyle('/projects')}>
+							<Link to='projects' className={getLinkStyle('/projects')}>
 								PROJECT
 							</Link>
 						</li>
 						<li>
-							<Link to="publications" className={getLinkStyle('/publications')}>
+							<Link to='publications' className={getLinkStyle('/publications')}>
 								PUBLICATIONS
 							</Link>
 						</li>
 						<li>
-							<Link to="lectures" className={getLinkStyle('/lectures')}>
+							<Link to='lectures' className={getLinkStyle('/lectures')}>
 								LECTURES
 							</Link>
 						</li>
 						<li>
-							<Link to="club" className={getLinkStyle('/club')}>
+							<Link to='club' className={getLinkStyle('/club')}>
 								전공동아리
 							</Link>
 						</li>
@@ -56,10 +56,10 @@ export default function Header() {
 								api 호출
 							</button>
 						</li>
-						<div className="relative rounded-full inline-flex mt-1.1">
-							<input className="py-2 pl-4 pr-2 text-black rounded-full" type="text" placeholder="Search" />
-							<button className="absolute top-0 right-0 mt-2 mr-2">
-								<img src="src/assets/images/header/magnifying-glass.png" alt="magnifying-glass" className="w-6" />
+						<div className='relative rounded-full inline-flex mt-1.1'>
+							<input className='py-2 pl-4 pr-2 text-black rounded-full' type='text' placeholder='Search' />
+							<button className='absolute top-0 right-0 mt-2 mr-2'>
+								<img src='../src/assets/images/header/magnifying-glass.png' alt='magnifying-glass' className='w-6' />
 							</button>
 						</div>
 					</ul>

--- a/src/pages/people/_components/section2.tsx
+++ b/src/pages/people/_components/section2.tsx
@@ -21,7 +21,7 @@ function Section2() {
             <li>Office : 광운대학교 새빛관 808호</li>
             <li><a href="https://sites.google.com/view/hcclab/people/schedule" className='underline underline-offset-1'>일정보기</a></li>
           </ul>
-          <a href="#director 주소 적기" target="_blank" rel="noopener noreferrer" className="inline-block w-[144.68px] h-[40px] bg-custom-blue rounded-full text-white filter drop-shadow-[0px 4px 4px rgba(0, 0, 0, 0.25)] flex justify-center items-center">자세히</a>
+          <a href="/people/professor" target="_blank" rel="noopener noreferrer" className="inline-block w-[144.68px] h-[40px] bg-custom-blue rounded-full text-white filter drop-shadow-[0px 4px 4px rgba(0, 0, 0, 0.25)] flex justify-center items-center">자세히</a>
         </div>
       </div>
     </section>

--- a/src/pages/professor/_components/section1.tsx
+++ b/src/pages/professor/_components/section1.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+function Section1 () {
+
+  
+    return (
+        <section className='relative w-full	h-[250px] left-0 right-0 bg-gradient-to-br from-custom-red to-custom-blue flex justify-center items-end pb-2'>
+        <div className='absolute bottom-0 inset-x-0 font-roboto font-bold text-5xl leading-6 flex items-center justify-center text-white' style={{ marginBottom: '80px' }}>
+          Director
+        </div>
+        <div className='absolute h-[300px] w-[250px] top-[110px] left-80 flex justify-center items-center'>
+          <img src='../src/assets/images/people/교수님.png' alt='박규동교수님 이미지' className='w-[250px] h-[250px] object-cover ' />
+        </div>
+        <div className='flex items-center justify-center px-8 py-2 mr-16'>
+          <p className='font-semibold text-white mr-4 text-xl'>박규동 (Kyudong Park, PhD)</p>
+          <p className='text-white text-xl'> | </p>
+          <p className='text-white text-xl ml-4'>공학박사 조교수</p>
+        </div>
+        <button 
+        className='absolute right-0 bottom-0 mb-4 mr-80 px-8 py-2 bg-white font-semibold shadow-md hover:bg-gray-100 rounded-3xl' 
+        type='button'>
+        ENG.ver.
+        </button>
+      </section>
+    );
+}
+
+export default Section1;

--- a/src/pages/professor/_components/section1.tsx
+++ b/src/pages/professor/_components/section1.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+// 교수님 프로필 이미지, 소개
 function Section1 () {
 
   

--- a/src/pages/professor/_components/section2.tsx
+++ b/src/pages/professor/_components/section2.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-// 교수님이 수업하신 강의 list
+// 교수님 연구실 소개, 연락처 정보
 function Section2 () {
 
     const copyEmail = async (text: string) => {

--- a/src/pages/professor/_components/section2.tsx
+++ b/src/pages/professor/_components/section2.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+// 교수님이 수업하신 강의 list
+function Section2 () {
+
+    const copyEmail = async (text: string) => {
+        try {
+            await navigator.clipboard.writeText(text);
+            alert('클립보드에 메일주소가 복사되었습니다.');
+        } catch (e) {
+            alert('복사에 실패했습니다.');
+        }
+    };
+
+    return (
+        <section className='relative w-full h-[280px] left-0 right-0'>
+             <div className='absolute h-[250px] w-[900px] left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 font-roboto text-custom-navy'>
+                <p className='relative left-48'>인공지능융합대학 정보융합학부 / 일반대학원 인공지능응용학과</p>
+                <div className='mt-6'>
+                    <p className='relative left-48'>
+                        컴퓨터공학을 기반으로 <strong>HCI/UX/</strong>인간공학과의 융합연구를 수행하여 박사학위를 받았습니다. 
+                        2번의 창업, 벤처인큐베이팅,<br /> 대기업의 다양한 근무 경험을 살려 지금은 인간-컴퓨터 상호작용 분야의 실용적인 교육과 연구를 수행하고 있습니다.
+                        <br /> 현재, 사용자 경험의 관점에서 소프트웨어를 설계/기획, 분석, 개발하는 <Link to='/' className='text-custom-blue underline font-semibold'>인간중심컴퓨팅 연구실</Link>을 운영하고 있습니다.
+                    </p>
+                </div>
+                <div className='relative left-56 mt-6'>
+                    <ul className='font-semibold list-disc'>
+                        <li>Email: <u className='cursor-pointer' onClick={() => copyEmail('kdpark@kw.ac.kr')}>kdpark@kw.ac.kr</u></li>
+                        <li>Tel: 02-940-5638</li>
+                        <li>Office: 서울시 노원구 광운로 20, 광운대학교 새빛관 804호</li>
+                    </ul>
+                </div>
+
+            </div>
+            
+        </section>
+    );
+}
+
+export default Section2;

--- a/src/pages/professor/_components/section3.tsx
+++ b/src/pages/professor/_components/section3.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+function Section3() {
+    return (
+        <section className='relative w-full h-[300px] left-0 right-0 bg-section-gray'>
+            <div className='absolute h-[150] w-[1000px] left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 font-roboto text-custom-navy'>
+                <div className='absolute h-[50px] w-full border-b-2 border-custom-blue'>
+                    <h2 className='absolute flex items-center text-3xl font-semibold tracking-widest'>Research Interests</h2>
+                </div>
+                <div className='pt-20 pl-6'>
+                    <ul className='list-disc'>
+                        <li className='mb-2'>인간 컴퓨터 상호작용 (소프트웨어 및 인공지능 서비스 개발)</li>
+                        <li className='mb-2'>데이터 기반 고객경험(CX) 분석 및 관리</li>
+                        <li className='mb-2'>디지털 접근성 (배리어프리), 재활 및 보조공학</li>
+                        <li>자율주행 자동차 인간공학</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    );
+}
+
+export default Section3;

--- a/src/pages/professor/_components/section3.tsx
+++ b/src/pages/professor/_components/section3.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// 교수님 연구 분야
 function Section3() {
     return (
         <section className='relative w-full h-[300px] left-0 right-0 bg-section-gray'>

--- a/src/pages/professor/_components/section4.tsx
+++ b/src/pages/professor/_components/section4.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// 교수님 연구 경험
 function Section4() {
 
     return (

--- a/src/pages/professor/_components/section4.tsx
+++ b/src/pages/professor/_components/section4.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+function Section4() {
+
+    return (
+        <section className='relative w-full h-[450px] left-0 right-0'>
+            <div className='absolute h-[350px] w-[1000px] left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 font-roboto text-custom-navy'>
+                <div className='absolute h-[50px] w-full border-b-2 border-custom-blue'>
+                    <h2 className='absolute flex items-center text-3xl font-semibold tracking-widest'>Work Experience</h2>
+                </div>
+                <div className='pt-20 pl-6'>
+                  <ul className='list-disc'>
+                    <li className='mb-2'>2020.09 - now 광운대학교 조교수</li>
+                    <li className='mb-2'>2019.01 - 2020.08 삼성SDS CX팀 Senior Engineer</li>
+                    <li className='mb-2'>2012.01 - 2018.12 포항공과대학교 연구조교</li>
+                    <li className='mb-2'>2014.01 - 2015.02 Beemeal, CTO</li>
+                    <li className='mb-2'>2013.07 - 2013.08 REDSTAR VENTURES (Boston, US), Intern</li>
+                    <li className='mb-2'>2012.07 - 2013.02 Funsumer, CTO</li>
+                    <li className='mb-2'>2011.03 - 2011.08 i-Care (Sydney, AUS), Intern</li>
+                    <li>2010.08 - 2013.02 삼성소프트웨어멤버십, 정회원</li>
+                  </ul>
+                </div>
+            </div>
+        </section>
+    );
+}
+
+export default Section4;

--- a/src/pages/professor/_components/section5.tsx
+++ b/src/pages/professor/_components/section5.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// 교수님 학력
 function Section5() {
     return (
         <section className='relative w-full h-[250px] left-0 right-0 bg-section-gray'>

--- a/src/pages/professor/_components/section5.tsx
+++ b/src/pages/professor/_components/section5.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+function Section5() {
+    return (
+        <section className='relative w-full h-[250px] left-0 right-0 bg-section-gray'>
+            <div className='absolute h-[150] w-[1000px] left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 font-roboto text-custom-navy'>
+                <div className='absolute h-[50px] w-full border-b-2 border-custom-blue'>
+                    <h2 className='absolute flex items-center text-3xl font-semibold tracking-widest'>Education</h2>
+                </div>
+                <div className='pt-20 pl-6'>
+                    <ul className='list-disc'>
+                        <li className='mb-2'>2012.03 - 2019.02 포항공과대학교 IT융합공학과 공학박사</li>
+                        <li className='mb-2'>2006.03 - 2012.02 경북대학교 컴퓨터학부 (국가이공계장학생)</li>
+                        <li>2003.03 - 2006.02 대구고등학교</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    );
+}
+
+export default Section5;

--- a/src/pages/professor/_components/section6.tsx
+++ b/src/pages/professor/_components/section6.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+function Section6() {
+    return (
+        <section className='relative w-full h-[650px] left-0 right-0'>
+            <div className='absolute h-[550px] w-[1000px] left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 font-roboto text-custom-navy'>
+                <div className='absolute h-[50px] w-full border-b-2 border-custom-blue'>
+                    <h2 className='absolute flex items-center text-3xl font-semibold tracking-widest'>초빙 강의 및 세미나</h2>
+                </div>
+                <div className='pt-20 pl-6'>
+                  <ul className='list-disc'>
+                    <li className='mb-2'>2024 C#을 활용한 키오스크 개발, 로보틱스 협동로봇SI 양성과정</li>
+                    <li className='mb-2'>2023 키오스크의 개념과 구성, 지능형 로봇 푸드테크 창업교육 과정</li>
+                    <li className='mb-2'>2023 SW기술 관점에서의 Connectivity & Value Design, KIA</li>
+                    <li className='mb-2'>2023 데이터 기반 UX의 현재와 미래, 코리아 HCI & UI/UX 그랜드 서밋 2023</li>
+                    <li className='mb-2'>2023 Human-centered Data Science, HCI Korea 학술대회, 튜토리얼 세션</li>
+                    <li className='mb-2'>2022 데이터와 CX의 현재와 미래, LG유플러스 CX College</li>
+                    <li className='mb-2'>2022 데이터사이언스 기초와 입문, 경희대학교 소프트웨어융합학과</li>
+                    <li className='mb-2'>2022 인공지능 교육을 위한 Python 기초 / 심화, 이화여자대학교 사범대학</li>
+                    <li className='mb-2'>2021 추천시스템의 원리와 활용, 이화여자대학교 교육공학과</li>
+                    <li className='mb-2'>2020 추천시스템 입문, 이화여자대학교 교육공학과</li>
+                    <li className='mb-2'>2020 HCI와 인공지능, 부산대학교 정보컴퓨터공학부</li>
+                    <li className='mb-2'>2020 B2B 도메인에서의 HCI, 포항공과대학교 산업경영공학과</li>
+                    <li className='mb-2'>2019 공학도 관점에서 바라본 UX 디자인, 인천대학교 산업경영공학과</li>
+                    <li className='mb-2'>2017 군집화 기법을 활용한 사용자 세그먼테이션, 포항공과대학교 산업경영공학과</li>
+                    <li className='mb-2'>2016 비전공자를 위한 컴퓨터공학 입문 및 모바일 어플리케이션 개발, 이화여자대학교 교육공학과</li>
+                  </ul>
+                </div>
+            </div>
+        </section>
+    );
+}
+
+export default Section6;

--- a/src/pages/professor/_components/section6.tsx
+++ b/src/pages/professor/_components/section6.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// 교수님이 하신 초빙 강의 및 세미나
 function Section6() {
     return (
         <section className='relative w-full h-[650px] left-0 right-0'>

--- a/src/pages/professor/_components/section7.tsx
+++ b/src/pages/professor/_components/section7.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// 전문 활동
 function Section7() {
     return (
         <section className='relative w-full h-[850px] left-0 right-0 bg-section-gray'>

--- a/src/pages/professor/_components/section7.tsx
+++ b/src/pages/professor/_components/section7.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+function Section7() {
+    return (
+        <section className='relative w-full h-[850px] left-0 right-0 bg-section-gray'>
+            <div className='absolute h-[750px] w-[1000px] left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 font-roboto text-custom-navy'>
+                <div className='absolute h-[50px] w-full border-b-2 border-custom-blue'>
+                    <h2 className='absolute flex items-center text-3xl font-semibold tracking-widest'>Professional Activities</h2>
+                </div>
+                <div className='pt-20 pl-6'>
+                    <ul className='list-disc'>
+                        <li className='mb-2'>활동 학회</li>
+                        <ul className='list-disc pl-8'>
+                          <li className='mb-2'>한국정보과학회 Computer Graphics & Interaction Society 운영이사</li>
+                          <li className='mb-2'>HCI Korea 2022 학술대회 프로그램위원장 (기술분야)</li>
+                          <li className='mb-2'>International Conference on Computers in Education 2014 박사컨소시엄위원회</li>
+                          <li className='mb-2'>Journal of Information Processing Systems, Associate Editor</li>
+                          <li className='mb-2'>ACM SIGCHI Member</li>
+                          <li className='mb-2'>대한인간공학회 종신회원, 평의원</li>
+                          <li className='mb-2'>한국HCI학회 종신회원</li>
+                          <li className='mb-2'>한국컴퓨터교육학회 정회원</li>
+                          <li className='mb-2'>대한산업공학회 정회원</li>
+                          <li className='mb-2'>한국정보과학회 정회원</li>
+                          <li className='mb-8'>한국재활복지공확회 정회원</li>
+                        </ul>
+                        <li className='mb-2'>심사활동</li>
+                        <ul className='list-disc pl-8'>
+                          <li className='mb-2'>IEEE Transactions on Software Engineering (SCIE)</li>
+                          <li className='mb-2'>Behavior & Information Technology (SSCI)</li>
+                          <li className='mb-2'>Mobile Information Systems (SCIE)</li>
+                          <li className='mb-2'>International Review of Research in Open and Distributed Learning (SSCI)</li>
+                          <li className='mb-2'>International Journal of Automotive Technology (SCIE)</li>
+                          <li className='mb-2'>Applied Sciences (SCIE)</li>
+                          <li className='mb-2'>Universal Access in the Information Society (SSCI)</li>
+                        </ul>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    );
+}
+
+export default Section7;

--- a/src/pages/professor/_components/section8.tsx
+++ b/src/pages/professor/_components/section8.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+function Section8() {
+    return (
+        <section className='relative w-full h-[450px] left-0 right-0'>
+            <div className='absolute h-[350px] w-[1000px] left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 font-roboto text-custom-navy'>
+                <div className='absolute h-[50px] w-full border-b-2 border-custom-blue'>
+                    <h2 className='absolute flex items-center text-3xl font-semibold tracking-widest'>Awards</h2>
+                </div>
+                <div className='pt-20 pl-6'>
+                  <ul className='list-disc'>
+                    <li className='mb-2'>2017 대한인간공학회 우수논문상</li>
+                    <li className='mb-2'>2016 기술사업화경진대회 미래창조과학부장관상</li>
+                    <li className='mb-2'>2016 포스텍 해커톤 대회 3위</li>
+                    <li className='mb-2'>2016 경북 SW융합센터 주관 빌게이츠 창업 아이디어 경진대회 1위</li>
+                    <li className='mb-2'>2015 포스텍 해커톤 대회 1위</li>
+                    <li className='mb-2'>2014 HCI학술대회 최우수논문상</li>
+                    <li className='mb-2'>2013 지식경제부 주관 검색결과 지식서비스 비즈니스플랜 공모전 2위</li>
+                    <li className='mb-2'>2012 한국과학기술단체총연합회 주관 과학기술정책아이디어 공모전 1위</li>
+                  </ul>
+                </div>
+            </div>
+        </section>
+    );
+}
+
+export default Section8;

--- a/src/pages/professor/_components/section8.tsx
+++ b/src/pages/professor/_components/section8.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// 교수님 수상 내역
 function Section8() {
     return (
         <section className='relative w-full h-[450px] left-0 right-0'>

--- a/src/pages/professor/page.tsx
+++ b/src/pages/professor/page.tsx
@@ -1,0 +1,23 @@
+import Section1 from './_components/section1';
+import Section2 from './_components/section2';
+import Section3 from './_components/section3';
+import Section4 from './_components/section4';
+import Section5 from './_components/section5';
+import Section6 from './_components/section6';
+import Section7 from './_components/section7';
+import Section8 from './_components/section8';
+
+export default function ProfessorPage() {
+	return ( 
+		<main className='mt-14'>
+			<Section1 />
+			<Section2 />
+			<Section3 />
+			<Section4 />
+            <Section5 />
+            <Section6 />
+            <Section7 />
+            <Section8 />
+		</main>
+	);
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,6 +8,7 @@ import ProjectsPage from '../pages/projects/page';
 import PublicationsPage from '../pages/publications/page';
 import LecturesPage from '../pages/lectures/page';
 import ClubPage from '../pages/club/page';
+import ProfessorPage from '../pages/professor/page';
 
 export default function Router() {
 	const elements = [
@@ -38,6 +39,10 @@ export default function Router() {
 				{
 					path: routes.club, // club
 					element: <ClubPage />,
+				},
+				{
+					path: routes.professor, // director
+					element: <ProfessorPage />,
 				},
 
 				{


### PR DESCRIPTION
 section1: Director title, 교수님 소개, ENG.ver 버튼
 section2: 교수님 연구실 소개
 section3: Research Interest
 section4: Work Experience
 section5: Education
 section6: 초빙 강의 및 세미나
 section7: Professional Activities
 section8: Awards

리스트는 <li> 태그를 이용했으며, 
헤더의 학교 로고 이미지와 search 바의 돋보기 이미지의 경로를 src/...에서 ../src/...로 바꿔주었고, professor 라우팅 설정을 people/professor로 했습니다. 